### PR TITLE
chore: fix typo CHANGELOG.md

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,7 +40,7 @@
 
 ### Minor Changes
 
-- 8a4c398: Gnosis Chidao chain now supported in client
+- 8a4c398: Gnosis Chiado chain now supported in client
 - 15ff607: getLatestCheckpointForAllChains endpoint is now supported in the client
 
 ## 0.1.16


### PR DESCRIPTION
The name of Gnosis Chidao chain is invalid, Chiado is correct.

Chidao => Chiado